### PR TITLE
Add logging output from the server

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,11 @@ app.set('views', path.join(__dirname, 'views'))
 app.set('view engine', 'ejs')
 
 app.get('/', (req, res) => {
+  console.log('Rendering `pages/index`')
+  console.log()
+  console.log('Use `console.log()` on the server to send text to stdout.')
+  console.log('That log text is viewable via the `heroku logs` command or via a logging add-on.')
+  console.log()
   res.render('pages/index')
 })
 


### PR DESCRIPTION
Currently nothing from the server logs when `/` is rendered, the only logs are from the router:

```
2024-12-05T22:12:31.218143+00:00 heroku[router]: at=info method=GET path="/" host=sheltered-eyrie-60144-d97e98d69373.herokuapp.com request_id=f2739cdb-62b2-464a-b2fe-2723ca64ff00 fwd="13.110.54.11" dyno=web.1 connect=0ms service=20ms status=304 bytes=152 protocol=https
2024-12-05T22:12:31.392858+00:00 heroku[router]: at=info method=GET path="/stylesheets/main.css" host=sheltered-eyrie-60144-d97e98d69373.herokuapp.com request_id=7c197cb2-09d7-43d0-ad43-59c8736291b1 fwd="13.110.54.11" dyno=web.1 connect=0ms service=8ms status=200 bytes=908 protocol=https
2024-12-05T22:12:31.506876+00:00 heroku[router]: at=info method=GET path="/lang-logo.png" host=sheltered-eyrie-60144-d97e98d69373.herokuapp.com request_id=1765623e-0a0a-48ce-9f4f-df7eff8bc381 fwd="13.110.54.11" dyno=web.1 connect=0ms service=11ms status=200 bytes=2567 protocol=https
```

This is what server logs look after this change:

```
2024-12-05T22:11:15.351801+00:00 heroku[router]: at=info method=GET path="/stylesheets/main.css" host=sheltered-eyrie-60144-d97e98d69373.herokuapp.com request_id=1bd60918-0c11-4c08-848a-d6bfb63ba7ae fwd="13.110.54.11" dyno=web.1 connect=0ms service=1ms status=304 bytes=237 protocol=https
2024-12-05T22:11:15.247601+00:00 heroku[router]: at=info method=GET path="/" host=sheltered-eyrie-60144-d97e98d69373.herokuapp.com request_id=e92141bc-eb31-4722-accb-5c9c243a4e00 fwd="13.110.54.11" dyno=web.1 connect=0ms service=2ms status=304 bytes=152 protocol=https
2024-12-05T22:11:15.246313+00:00 app[web.1]: Rendering `pages/index`
2024-12-05T22:11:15.246329+00:00 app[web.1]:
2024-12-05T22:11:15.246330+00:00 app[web.1]: Use `console.log()` on the server to send text to stdout.
2024-12-05T22:11:15.246349+00:00 app[web.1]: That log text is viewable via the `heroku logs` command or via a logging add-on.
2024-12-05T22:11:15.246349+00:00 app[web.1]: 
2024-12-05T22:11:15.353613+00:00 heroku[router]: at=info method=GET path="/lang-logo.png" host=sheltered-eyrie-60144-d97e98d69373.herokuapp.com request_id=4229139a-67a0-4dbe-b568-561e11768143 fwd="13.110.54.11" dyno=web.1 connect=0ms service=1ms status=304 bytes=237 protocol=https
```

This accomplishes:

- Showing how router and web logs will differ. 
- Explaining via text in the logs how they can log (`console.log()`) as opposed to some people expecting to write to a log file on disk.
- Explaining how to view those logs (the `heroku logs` command)
- Hinting that a logging add-on might be a good idea